### PR TITLE
Fix: Remove console.log on contentapi.js

### DIFF
--- a/react-app/src/api/contentAPI.js
+++ b/react-app/src/api/contentAPI.js
@@ -110,8 +110,7 @@ export const getSubscriptionDetail = async body => {
         },
         data: body
     })
-    console.log(response);
-        return response;
+    return response;
 };
 
 export const checkToken = async () => {


### PR DESCRIPTION
# Fix Remove console.log on contentapi.js

I saw there was a `console.log()` probably used for developing reasons and removed it 😄 